### PR TITLE
Add auth middleware for socket-io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,21 @@
       "version": "0.0.0",
       "dependencies": {
         "connect-redis": "^7.1.1",
+        "cookie": "^0.6.0",
         "csurf": "^1.11.0",
         "express": "4.16.4",
+        "lodash": "^4.17.21",
         "redis": "^4.6.14",
         "socket.io": "^4.7.5"
       },
       "devDependencies": {
+        "@types/cookie": "^0.6.0",
         "@types/cookie-parser": "^1.4.7",
         "@types/csurf": "^1.11.5",
         "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.21",
         "@types/express-session": "^1.18.0",
+        "@types/lodash.get": "^4.4.9",
         "@types/socket.io": "^3.0.2",
         "cookie-parser": "^1.4.6",
         "express-session": "^1.18.0",
@@ -166,9 +170,10 @@
       }
     },
     "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
     },
     "node_modules/@types/cookie-parser": {
       "version": "1.4.7",
@@ -244,6 +249,21 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.get": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.9.tgz",
+      "integrity": "sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -421,9 +441,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -625,6 +645,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/engine.io/node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
     "node_modules/engine.io/node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -725,14 +750,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/express-session/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -744,6 +761,14 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/safe-buffer": {
@@ -829,6 +854,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,21 @@
   },
   "dependencies": {
     "connect-redis": "^7.1.1",
+    "cookie": "^0.6.0",
     "csurf": "^1.11.0",
     "express": "4.16.4",
+    "lodash": "^4.17.21",
     "redis": "^4.6.14",
     "socket.io": "^4.7.5"
   },
   "devDependencies": {
+    "@types/cookie": "^0.6.0",
     "@types/cookie-parser": "^1.4.7",
     "@types/csurf": "^1.11.5",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.21",
     "@types/express-session": "^1.18.0",
+    "@types/lodash.get": "^4.4.9",
     "@types/socket.io": "^3.0.2",
     "cookie-parser": "^1.4.6",
     "express-session": "^1.18.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,7 +52,7 @@ app.use(errorHandlers.notFound);
 
 export const httpServer = createServer(app);
 
-establishSocketIOServer(httpServer);
+establishSocketIOServer();
 
 httpServer
   .listen(config.port, () => {

--- a/src/socket-io/index.ts
+++ b/src/socket-io/index.ts
@@ -2,6 +2,7 @@ import { Server as SocketIOServer } from "socket.io";
 import { Server as HttpServer } from "http";
 import { Socket } from "socket.io";
 import { httpServer as ExpressAppHttpServer } from "../app";
+import { socketAuth } from "./middleware";
 
 const getIOServerInstance = (httpServer: HttpServer): SocketIOServer => {
   const io = new SocketIOServer(httpServer);
@@ -12,10 +13,11 @@ const onSocketConnection = (socket: Socket): void => {
   socket.emit("message", { message: "Hey!" });
 };
 
-const establishSocketIOServer = (httpServer: HttpServer): void => {
+const establishSocketIOServer = (): void => {
   const io = getIOServerInstance(ExpressAppHttpServer);
 
   const chatterbox = io.of("/chatterbox");
+  chatterbox.use(socketAuth);
   chatterbox.on("connection", onSocketConnection);
 };
 

--- a/src/socket-io/middleware.ts
+++ b/src/socket-io/middleware.ts
@@ -1,0 +1,46 @@
+import { Socket } from "socket.io";
+import { ExtendedError } from "socket.io/dist/namespace";
+import { parse } from "cookie";
+import cookieParser from "cookie-parser";
+import config from "../config";
+import { get } from "lodash";
+
+const getNotAuthenticatedError = () => {
+  return new Error("Not Authenticated");
+};
+
+const socketAuth = (socket: Socket, next: (err?: ExtendedError) => void) => {
+  try {
+    const handshake = socket.request;
+    const parsedCookie = parse(handshake.headers.cookie!);
+
+    if (!handshake.headers.cookie) {
+      console.log("No cookies present in the handshake.");
+      return next(getNotAuthenticatedError());
+    }
+
+    const rawSid = get(parsedCookie, "connect.sid");
+    if (!rawSid) {
+      console.log("Session ID cookie is missing.");
+      return next(getNotAuthenticatedError());
+    }
+
+    const sid = cookieParser.signedCookie(
+      rawSid,
+      config.sessionSecret as string
+    );
+
+    if (rawSid !== sid) {
+      console.log("Session ID mismatch.");
+      return next(new Error("Not Authenticated"));
+    }
+
+    // Authentication successful
+    console.log("Authentication successful.");
+    next();
+  } catch (error) {
+    return next(new Error("Authentication issue..."));
+  }
+};
+
+export { socketAuth };


### PR DESCRIPTION
This PR introduces a basic authentication middleware for the `socket-io` server. The middleware checks if an incoming client connection has a `cookie`, and if this cookie has a valid signed `session ID`. In the event that auth fails, the client's connection request is rejected.