### PR TITLE
Resolve string to Buffer issue in scmp

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ app.get(config.routes.login, routes.login);
 app.get(config.routes.chat, util.requireAuthentication, routes.chat);
 app.get("/error", (req, res, next) => next(new Error("A Contrived Error!")));
 app.get(config.routes.logout, routes.logOut);
-app.get(config.routes.register, routes.register)
-app.post(config.routes.register, routes.registerProcess)
+app.get(config.routes.register, routes.register);
+app.post(config.routes.register, routes.registerProcess);
 
 passportRoutes(app);
 

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -52,13 +52,16 @@ passport.use(
     new LocalStrategy((username: string, password: string, done: Function) => {
         user.findByUsername(username, (err: Error | null, profile: User) => {
             if (profile) {
+                console.log("User attempting login...");
+                console.log(profile);
                 passwordUtils.checkPassword(
                     password,
-                    get(profile, password),
+                    get(profile, "password"),
                     get(profile, "salt"),
                     get(profile, "work"),
                     (err: Error | null, isAuth: boolean) => {
                         if (isAuth) {
+                            console.log("User authenticated locally.");
                             if (
                                 get(profile, "work") < config.crypto.workFactor
                             ) {

--- a/src/passport/model/user.d.ts
+++ b/src/passport/model/user.d.ts
@@ -5,6 +5,7 @@ type User = {
     id: string;
     provider: string;
     username: string;
+    password: string;
 };
 
 type UsersType = {

--- a/src/passport/password.ts
+++ b/src/passport/password.ts
@@ -40,7 +40,13 @@ const checkPassword = (
         config.crypto.keylen,
         "sha256",
         (err: Error | null, key: Buffer) => {
-            callback(null, scmp(key.toString("base64"), derivedPassword));
+            callback(
+                null,
+                scmp(
+                    Buffer.from(key.toString("base64")),
+                    Buffer.from(derivedPassword),
+                ),
+            );
         },
     );
 };

--- a/src/passport/user.ts
+++ b/src/passport/user.ts
@@ -23,15 +23,15 @@ const addUser = (
             (err: Error | null, salt: number, password: string) => {
                 set(Users, username, {
                     salt: salt,
-                    password: password,
                     work: work,
                     displayName: username,
                     id: uuidv4(),
                     provider: "local",
                     username: username,
+                    password: password,
                 });
-                console.log("User created!")
-                console.log(Users)
+                console.log("User created!");
+                console.log(Users);
             },
         );
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import * as util from "../middleware/utilities";
 import config from "../config";
-import * as user from "../passport/user"
+import * as user from "../passport/user";
 import { User } from "../passport/model/user";
 
 export const index = (req: Request, res: Response) => {
@@ -22,23 +22,26 @@ export const logOut = (req: Request, res: Response) => {
 };
 
 export const register = (req: Request, res: Response) => {
-  res.send("Register")
-}
+    res.send("Register");
+};
 
-export const registerProcess =(req: Request, res: Response) => {
-  if (req.body.username && req.body.password) {
-    user.addUser(req.body.username, req.body.password, config.crypto.workFactor, (err: Error | null, profile: User) => {
-      if (err) {
-        res.redirect(config.routes.register)
-      }
-      else {
-        req.login(profile, (err: Error | null) => {
-          res.redirect(config.routes.chat)
-        })
-      }
-    })
-  }
-  else {
-    res.redirect(config.routes.register)
-  }
-}
+export const registerProcess = (req: Request, res: Response) => {
+    if (req.body.username && req.body.password) {
+        user.addUser(
+            req.body.username,
+            req.body.password,
+            config.crypto.workFactor,
+            (err: Error | null, profile: User) => {
+                if (err) {
+                    res.redirect(config.routes.register);
+                } else {
+                    req.login(profile, (err: Error | null) => {
+                        res.redirect(config.routes.chat);
+                    });
+                }
+            },
+        );
+    } else {
+        res.redirect(config.routes.register);
+    }
+};


### PR DESCRIPTION
This PR introduces a fix for the `scmp` method, whereby both the `derivedPassword` and `key` were originally strings. Both have been converted to `Buffer`. Small log for `logOut` was also added.